### PR TITLE
Add `source' field to routing table entries

### DIFF
--- a/desktop/mtrie.c
+++ b/desktop/mtrie.c
@@ -71,6 +71,7 @@ int main(int argc, char *argv[])
       table.entries[i].keymask.key = t.key;
       table.entries[i].keymask.mask = t.mask;
       table.entries[i].route = t.route;
+      table.entries[i].source = t.source;
     }
 
     // Perform the minimisation
@@ -88,7 +89,7 @@ int main(int argc, char *argv[])
         // Copy relevant fields across
         table.entries[i].keymask.key,
         table.entries[i].keymask.mask,
-        0x0,  // No source
+        table.entries[i].source,
         table.entries[i].route,
       };
       fwrite(&t, sizeof(fentry_t), 1, out_file);

--- a/desktop/ordered_covering.c
+++ b/desktop/ordered_covering.c
@@ -121,6 +121,7 @@ int main(int argc, char *argv[])
       table.entries[i].keymask.key = t.key;
       table.entries[i].keymask.mask = t.mask;
       table.entries[i].route = t.route;
+      table.entries[i].source = t.source;
     }
 
     // Sort the table
@@ -141,7 +142,7 @@ int main(int argc, char *argv[])
         // Copy relevant fields across
         table.entries[i].keymask.key,
         table.entries[i].keymask.mask,
-        0x0,  // No source
+        table.entries[i].source,
         table.entries[i].route,
       };
       fwrite(&t, sizeof(fentry_t), 1, out_file);

--- a/include/aliases.h
+++ b/include/aliases.h
@@ -12,13 +12,20 @@
 /* Vector-like object ********************************************************/
 
 
+typedef struct _alias_element_t  // Element of an alias list
+{
+  keymask_t keymask;  // Keymask of the element
+  uint32_t source;    // Source of packets matching the element
+} alias_element_t;
+
+
 typedef struct _alias_list_t
 {
   // Linked list of arrays
   unsigned int n_elements;     // Elements in this instance
   unsigned int max_size;       // Max number of elements in this instance
   struct _alias_list_t *next;  // Next element in list of lists
-  keymask_t data;              // Data region
+  alias_element_t data;        // Data region
 } alias_list_t;
 
 
@@ -27,7 +34,7 @@ static inline alias_list_t* alias_list_new(unsigned int max_size)
 {
   // Compute how much memory to allocate
   unsigned int size = sizeof(alias_list_t) +
-                      (max_size - 1)*sizeof(keymask_t);
+                      (max_size - 1)*sizeof(alias_element_t);
 
   // Allocate and then fill in values
   alias_list_t *as = MALLOC(size);
@@ -40,11 +47,14 @@ static inline alias_list_t* alias_list_new(unsigned int max_size)
 
 
 // Append an element to a list
-static inline bool alias_list_append(alias_list_t *as, keymask_t val)
+static inline bool alias_list_append(alias_list_t *as,
+                                     keymask_t val,
+                                     uint32_t source)
 {
   if (as->n_elements < as->max_size)
   {
-    (&as->data)[as->n_elements] = val;
+    (&as->data)[as->n_elements].keymask = val;
+    (&as->data)[as->n_elements].source = source;
     as->n_elements++;
 
     return true;
@@ -58,7 +68,7 @@ static inline bool alias_list_append(alias_list_t *as, keymask_t val)
 
 
 // Get an element from the list
-static inline keymask_t alias_list_get(alias_list_t *as, unsigned int i)
+static inline alias_element_t alias_list_get(alias_list_t *as, unsigned int i)
 {
   return (&as->data)[i];
 }

--- a/include/merge.h
+++ b/include/merge.h
@@ -10,6 +10,7 @@ typedef struct _merge_t
 
   keymask_t keymask; // Keymask resulting from the merge
   uint32_t route;    // Route taken by entries in the merge
+  uint32_t source;   // Collective source of entries in the route
 } merge_t;
 
 
@@ -23,6 +24,7 @@ static inline void merge_clear(merge_t* m)
   m->keymask.key  = 0xffffffff;  // !!!...
   m->keymask.mask = 0x00000000;  // Matches nothing
   m->route = 0x0;
+  m->source = 0x0;
 }
 
 
@@ -76,6 +78,7 @@ static inline void merge_add(merge_t* m, unsigned int i)
 
     // Add the route
     m->route |= e.route;
+    m->source |= e.source;
   }
 }
 
@@ -95,6 +98,7 @@ static inline void merge_remove(merge_t* m, unsigned int i)
   {
     // Rebuild the key and mask from scratch
     m->route = 0x0;
+    m->source = 0x0;
     m->keymask.key  = 0xffffffff;
     m->keymask.mask = 0x000000000;
     for (unsigned int j = 0; j < m->table->size; j++)
@@ -104,6 +108,7 @@ static inline void merge_remove(merge_t* m, unsigned int i)
       if (bitset_contains(&(m->entries), j))
       {
         m->route |= e.route;
+        m->source |= e.source;
         if (m->keymask.key  == 0xffffffff && m->keymask.mask == 0x00000000)
         {
           // Initialise the keymask

--- a/include/ordered_covering.h
+++ b/include/ordered_covering.h
@@ -251,7 +251,7 @@ static inline void oc_downcheck(merge_t *m, int min_goodness, aliases_t *a)
           {
             for (unsigned int j = 0; j < l->n_elements; j++)
             {
-              km = alias_list_get(l, j);
+              km = alias_list_get(l, j).keymask;
 
               if (keymask_intersect(km, m->keymask))
               {
@@ -413,6 +413,7 @@ static inline void oc_merge_apply(merge_t *m, aliases_t *aliases)
   entry_t new_entry;
   new_entry.keymask = m->keymask;
   new_entry.route = m->route;
+  new_entry.source = m->source;
 
   // Get the insertion point for the new entry
   unsigned int insertion_point = oc_get_insertion_point(
@@ -454,6 +455,7 @@ static inline void oc_merge_apply(merge_t *m, aliases_t *aliases)
       // Otherwise update the aliases table to account for the entry which is
       // being merged.
       keymask_t km = table->entries[remove].keymask;
+      uint32_t source = table->entries[remove].source;
       if (aliases_contains(aliases, km))
       {
         // Join the old list of aliases with the new
@@ -465,7 +467,7 @@ static inline void oc_merge_apply(merge_t *m, aliases_t *aliases)
       else
       {
         // Include the keymask in the new list of aliases
-        alias_list_append(new_aliases, km);
+        alias_list_append(new_aliases, km, source);
       }
 
       // Decrement the final table size to account for this entry being removed.

--- a/include/routing_table.h
+++ b/include/routing_table.h
@@ -48,6 +48,7 @@ typedef struct _entry_t
 {
   keymask_t keymask;  // Key and mask
   uint32_t route;     // Routing direction
+  uint32_t source;    // Source of packets arriving at this entry
 } entry_t;
 
 

--- a/tests/test_aliases.c
+++ b/tests/test_aliases.c
@@ -12,17 +12,18 @@ START_TEST(test_aliases_list)
 
   // Add an element
   keymask_t km = {0x0, 0xf};
-  alias_list_append(l1, km);
+  alias_list_append(l1, km, 0b01001);
   ck_assert_int_eq(l1->n_elements, 1);  // Now contains 1 element
-  ck_assert(alias_list_get(l1, 0).key == km.key);  // Check the element is expected
-  ck_assert(alias_list_get(l1, 0).mask == km.mask);  // Check the element is expected
+  ck_assert(alias_list_get(l1, 0).keymask.key == km.key);  // Check the element is expected
+  ck_assert(alias_list_get(l1, 0).keymask.mask == km.mask);  // Check the element is expected
+  ck_assert(alias_list_get(l1, 0).source == 0b01001);  // Check the element is expected
 
   // This should cause no problems with memory accesses
-  ck_assert(alias_list_append(l1, km));
-  ck_assert(alias_list_append(l1, km));
-  ck_assert(alias_list_append(l1, km));
-  ck_assert(alias_list_append(l1, km));
-  ck_assert(!alias_list_append(l1, km));  // This will be a problem!
+  ck_assert(alias_list_append(l1, km, 0x0));
+  ck_assert(alias_list_append(l1, km, 0x0));
+  ck_assert(alias_list_append(l1, km, 0x0));
+  ck_assert(alias_list_append(l1, km, 0x0));
+  ck_assert(!alias_list_append(l1, km, 0x0));  // This will be a problem!
 
   // Create a new alias list and append it to the existing list
   alias_list_t *l2 = alias_list_new(10);

--- a/tests/test_merge.c
+++ b/tests/test_merge.c
@@ -7,11 +7,11 @@ START_TEST(test_merge_lifecycle)
 {
   // Create a routing table from which we'll build merges
   entry_t entries[] = {
-    {{0x0, 0xf}, 0b001},
-    {{0x1, 0xf}, 0b001},
-    {{0x2, 0xf}, 0b001},
-    {{0x6, 0xf}, 0b001},
-    {{0x0, 0x0}, 0b111},
+    {{0x0, 0xf}, 0b001, 0b00001},
+    {{0x1, 0xf}, 0b001, 0b00010},
+    {{0x2, 0xf}, 0b001, 0b00100},
+    {{0x6, 0xf}, 0b001, 0b01000},
+    {{0x0, 0x0}, 0b111, 0b10000},
   };
   table_t table = {5, entries};
 
@@ -32,6 +32,7 @@ START_TEST(test_merge_lifecycle)
   ck_assert_int_eq(m.keymask.key, 0x2);
   ck_assert_int_eq(m.keymask.mask, 0xf);
   ck_assert_int_eq(m.route, 0x1);
+  ck_assert_int_eq(m.source, 0b00100);
 
   // Add another entry to a merge and then check that the resultant key-mask is
   // correct.
@@ -39,6 +40,7 @@ START_TEST(test_merge_lifecycle)
   ck_assert_int_eq(m.keymask.key,  0b0010);
   ck_assert_int_eq(m.keymask.mask, 0b1011);
   ck_assert_int_eq(m.route, 0x1);
+  ck_assert_int_eq(m.source, 0b01100);
 
   ck_assert(!merge_contains(&m, 0));
   ck_assert(!merge_contains(&m, 1));
@@ -50,6 +52,7 @@ START_TEST(test_merge_lifecycle)
   ck_assert_int_eq(m.keymask.key,  0b0000);
   ck_assert_int_eq(m.keymask.mask, 0b1000);
   ck_assert_int_eq(m.route, 0x1);
+  ck_assert_int_eq(m.source, 0b01110);
 
   // Remove an entry from the table and ensure that the keymask is recalculated
   // correctly and that the route is correct.
@@ -57,16 +60,19 @@ START_TEST(test_merge_lifecycle)
   ck_assert_int_eq(m.keymask.key,  0b0000);
   ck_assert_int_eq(m.keymask.mask, 0b1100);
   ck_assert_int_eq(m.route, 0x1);
+  ck_assert_int_eq(m.source, 0b00110);
 
   merge_remove(&m, 2);  // Merge is now a merge of only 0001
   ck_assert_int_eq(m.keymask.key,  0b0001);
   ck_assert_int_eq(m.keymask.mask, 0b1111);
   ck_assert_int_eq(m.route, 0x1);
+  ck_assert_int_eq(m.source, 0b00010);
 
   merge_remove(&m, 1);  // Merge is now empty
   ck_assert_int_eq(m.keymask.key,  0xffffffff);
   ck_assert_int_eq(m.keymask.mask, 0x00000000);
   ck_assert_int_eq(m.route, 0x0);
+  ck_assert_int_eq(m.source, 0b00000);
 
   // Delete the merge
   merge_delete(&m);

--- a/tests/test_mtrie.c
+++ b/tests/test_mtrie.c
@@ -12,15 +12,15 @@ START_TEST(test_insert_and_count)
   ck_assert_int_eq(mtrie_count(root), 0);
 
   // Add a single entry, check that a single entry is reported
-  mtrie_insert(root, 0x00000000, 0xffffffff);
+  mtrie_insert(root, 0x00000000, 0xffffffff, 0x0);
   ck_assert_int_eq(mtrie_count(root), 1);
 
   // Add a different entry, check that two entries are reported
-  mtrie_insert(root, 0x00000011, 0xffffffff);
+  mtrie_insert(root, 0x00000011, 0xffffffff, 0x0);
   ck_assert_int_eq(mtrie_count(root), 2);
 
   // Add a different entry, check that three entries are reported
-  mtrie_insert(root, 0x00000111, 0xfffff7ff);
+  mtrie_insert(root, 0x00000111, 0xfffff7ff, 0x0);
   ck_assert_int_eq(mtrie_count(root), 3);
 
   // Clear the tree up
@@ -35,23 +35,26 @@ START_TEST(test_serialise)
   mtrie_t *root = mtrie_new();  // Create the new m-Trie
 
   // Add some entries to the trie
-  mtrie_insert(root, 0x00000000, 0xffffffff);
-  mtrie_insert(root, 0x00000011, 0xffffffff);
-  mtrie_insert(root, 0x00000111, 0xfffff7ff);
+  mtrie_insert(root, 0x00000000, 0xffffffff, 0b001);
+  mtrie_insert(root, 0x00000011, 0xffffffff, 0b010);
+  mtrie_insert(root, 0x00000111, 0xfffff7ff, 0b100);
 
   // Extract entries
-  keymask_t entries[3];
+  mtrie_entry_t entries[3];
   mtrie_get_entries(root, entries);
 
   // Check the entries are correct
-  ck_assert_int_eq(entries[0].key, 0x0);
-  ck_assert_int_eq(entries[0].mask, 0xffffffff);
+  ck_assert_int_eq(entries[0].keymask.key, 0x0);
+  ck_assert_int_eq(entries[0].keymask.mask, 0xffffffff);
+  ck_assert_int_eq(entries[0].source, 0b001);
 
-  ck_assert_int_eq(entries[1].key, 0x11);
-  ck_assert_int_eq(entries[1].mask, 0xffffffff);
+  ck_assert_int_eq(entries[1].keymask.key, 0x11);
+  ck_assert_int_eq(entries[1].keymask.mask, 0xffffffff);
+  ck_assert_int_eq(entries[1].source, 0b010);
 
-  ck_assert_int_eq(entries[2].key, 0x111);
-  ck_assert_int_eq(entries[2].mask, 0xfffff7ff);
+  ck_assert_int_eq(entries[2].keymask.key, 0x111);
+  ck_assert_int_eq(entries[2].keymask.mask, 0xfffff7ff);
+  ck_assert_int_eq(entries[2].source, 0b100);
 
   // Clear the tree up
   mtrie_delete(root);
@@ -81,16 +84,17 @@ START_TEST(test_insert_and_merge_leaves)
   mtrie_t *root = mtrie_new();  // Create the new m-Trie
 
   // Add two entries which can be merged and ensure that they are merged
-  mtrie_insert(root, stim.a.key, stim.a.mask);
-  mtrie_insert(root, stim.b.key, stim.b.mask);
+  mtrie_insert(root, stim.a.key, stim.a.mask, 0b1000);
+  mtrie_insert(root, stim.b.key, stim.b.mask, 0b0100);
   ck_assert_int_eq(mtrie_count(root), 1);
 
   // Check the entry is correct
-  keymask_t entry;
+  mtrie_entry_t entry;
   mtrie_get_entries(root, &entry);
 
-  ck_assert_int_eq(entry.key, 0x0);
-  ck_assert_int_eq(entry.mask, 0xfffffffe);
+  ck_assert_int_eq(entry.keymask.key, 0x0);
+  ck_assert_int_eq(entry.keymask.mask, 0xfffffffe);
+  ck_assert_int_eq(entry.source, 0b1100);
 
   // Clear the tree up
   mtrie_delete(root);
@@ -115,16 +119,17 @@ START_TEST(test_insert_and_merge_nodes)
   mtrie_t *root = mtrie_new();  // Create the new m-Trie
 
   // Add two entries which can be merged and ensure that they are merged
-  mtrie_insert(root, stim.a.key, stim.a.mask);
-  mtrie_insert(root, stim.b.key, stim.b.mask);
+  mtrie_insert(root, stim.a.key, stim.a.mask, 0b01);
+  mtrie_insert(root, stim.b.key, stim.b.mask, 0b10);
   ck_assert_int_eq(mtrie_count(root), 1);
 
   // Check the entry is correct
-  keymask_t entry;
+  mtrie_entry_t entry;
   mtrie_get_entries(root, &entry);
 
-  ck_assert_int_eq(entry.key, 0x0);
-  ck_assert_int_eq(entry.mask, 0xfffffffd);
+  ck_assert_int_eq(entry.keymask.key, 0x0);
+  ck_assert_int_eq(entry.keymask.mask, 0xfffffffd);
+  ck_assert_int_eq(entry.source, 0b11);
 
   // Clear the tree up
   mtrie_delete(root);
@@ -138,20 +143,22 @@ START_TEST(test_insert_and_merge_partial)
   mtrie_t *root = mtrie_new();  // Create the new m-Trie
 
   // Add three entries, of which only the latter two can be merged
-  mtrie_insert(root, 0b0101, 0b1111);
-  mtrie_insert(root, 0b0000, 0b1111);
-  mtrie_insert(root, 0b1000, 0b1111);
+  mtrie_insert(root, 0b0101, 0b1111, 0b001);
+  mtrie_insert(root, 0b0000, 0b1111, 0b010);
+  mtrie_insert(root, 0b1000, 0b1111, 0b100);
   ck_assert_int_eq(mtrie_count(root), 2);
 
   // Check the entry is correct
-  keymask_t entries[2];
+  mtrie_entry_t entries[2];
   mtrie_get_entries(root, entries);
 
-  ck_assert_int_eq(entries[0].key, 0b0101);
-  ck_assert_int_eq(entries[0].mask, 0b1111);
+  ck_assert_int_eq(entries[0].keymask.key, 0b0101);
+  ck_assert_int_eq(entries[0].keymask.mask, 0b1111);
+  ck_assert_int_eq(entries[0].source, 0b001);
 
-  ck_assert_int_eq(entries[1].key, 0b0000);
-  ck_assert_int_eq(entries[1].mask, 0b0111);
+  ck_assert_int_eq(entries[1].keymask.key, 0b0000);
+  ck_assert_int_eq(entries[1].keymask.mask, 0b0111);
+  ck_assert_int_eq(entries[1].source, 0b110);
 
   // Clear the tree up
   mtrie_delete(root);
@@ -163,34 +170,34 @@ START_TEST(test_mtrie_minimise)
   // Test minimisation of a routing table using m-Trie
   // Test that the given table is minimised correctly:
   //
-  //   0000 -> N NE
-  //   0001 -> N NE
-  //   0010 -> E
-  //   0011 -> E
-  //   010X -> SW
-  //   0110 -> SW
-  //   0111 -> SW
-  //   1010 -> N
-  //   1001 -> N
+  //   S  -> 0000 -> N NE
+  //   SW -> 0001 -> N NE
+  //   N  -> 0010 -> E
+  //   S  -> 0011 -> E
+  //   N  -> 010X -> SW
+  //   N  -> 0110 -> SW
+  //   N  -> 0111 -> SW
+  //   W  -> 1010 -> N
+  //   W  -> 1001 -> N
   //
   // The result (worked out by hand) should be:
   //
-  //   000X -> N NE
-  //   001X -> E
-  //   01XX -> SW
-  //   1001 -> N
-  //   1010 -> N
+  //   SW S -> 000X -> N NE
+  //   N S  -> 001X -> E
+  //   N    -> 01XX -> SW
+  //   W    -> 1001 -> N
+  //   W    -> 1010 -> N
   //
   entry_t entries[] = {
-    {{0b0000, 0xf}, 0b000110},
-    {{0b0001, 0xf}, 0b000110},
-    {{0b0010, 0xf}, 0b000001},
-    {{0b0011, 0xf}, 0b000001},
-    {{0b0100, 0xe}, 0b010000},
-    {{0b0110, 0xf}, 0b010000},
-    {{0b0111, 0xf}, 0b010000},
-    {{0b1010, 0xf}, 0b000100},
-    {{0b1001, 0xf}, 0b000100},
+    {{0b0000, 0xf}, 0b000110, 0b100000},
+    {{0b0001, 0xf}, 0b000110, 0b010000},
+    {{0b0010, 0xf}, 0b000001, 0b000100},
+    {{0b0011, 0xf}, 0b000001, 0b100000},
+    {{0b0100, 0xe}, 0b010000, 0b000100},
+    {{0b0110, 0xf}, 0b010000, 0b000100},
+    {{0b0111, 0xf}, 0b010000, 0b000100},
+    {{0b1010, 0xf}, 0b000100, 0b001000},
+    {{0b1001, 0xf}, 0b000100, 0b001000},
   };
   table_t table = {sizeof(entries) / sizeof(entry_t), entries};
 
@@ -204,22 +211,27 @@ START_TEST(test_mtrie_minimise)
   ck_assert_int_eq(table.entries[0].keymask.key, 0b0000);
   ck_assert_int_eq(table.entries[0].keymask.mask, 0b1110);
   ck_assert_int_eq(table.entries[0].route, 0b000110);
+  ck_assert_int_eq(table.entries[0].source, 0b110000);
 
   ck_assert_int_eq(table.entries[1].keymask.key, 0b0010);
   ck_assert_int_eq(table.entries[1].keymask.mask, 0b1110);
   ck_assert_int_eq(table.entries[1].route, 0b000001);
+  ck_assert_int_eq(table.entries[1].source, 0b100100);
 
   ck_assert_int_eq(table.entries[2].keymask.key, 0b0100);
   ck_assert_int_eq(table.entries[2].keymask.mask, 0b1100);
   ck_assert_int_eq(table.entries[2].route, 0b010000);
+  ck_assert_int_eq(table.entries[2].source, 0b000100);
 
   ck_assert_int_eq(table.entries[3].keymask.key, 0b1001);
   ck_assert_int_eq(table.entries[3].keymask.mask, 0b1111);
   ck_assert_int_eq(table.entries[3].route, 0b000100);
+  ck_assert_int_eq(table.entries[3].source, 0b001000);
 
   ck_assert_int_eq(table.entries[4].keymask.key, 0b1010);
   ck_assert_int_eq(table.entries[4].keymask.mask, 0b1111);
   ck_assert_int_eq(table.entries[4].route, 0b000100);
+  ck_assert_int_eq(table.entries[4].source, 0b001000);
 }
 END_TEST
 


### PR DESCRIPTION
Allows for removal of default routes in future.  This is also the first step toward allowing Rig to use a C implementation of OC, if available.

The alias table in OC is extended so that each entry is a `{{key, mask}, source}` type. The end nodes in mTrie are modified to hold a `source` as well.